### PR TITLE
Added sources for current landscape of fish length estimation and laser triangulation rangefinders

### DIFF
--- a/references/fishsense.bib
+++ b/references/fishsense.bib
@@ -429,6 +429,66 @@ To the best of our knowledge, this is the first study connecting image enhanceme
   groups = {Image Processing},
 }
 
+@Article{nguyen1995simple,
+  author  = {Nguyen, Hoa G and Blackburn, Michael R},
+  journal = {Technical Document},
+  title   = {A simple method for range finding via laser triangulation},
+  year    = {1995},
+  volume  = {2734},
+  groups  = {Laser Rangefinder},
+}
+
+@Article{Barreto2013,
+  author  = {Saulo Vinicius Ferreira Barreto and Remy Eskinazi Sant'Anna and Marc{\'i}lio Andr{\'e} F{\'e}lix Feitosa},
+  journal = {2013 IEEE 20th International Conference on Electronics, Circuits, and Systems (ICECS)},
+  title   = {A method for image processing and distance measuring based on laser distance triangulation},
+  year    = {2013},
+  pages   = {695-698},
+  groups  = {Laser Rangefinder},
+  url     = {https://api.semanticscholar.org/CorpusID:17466529},
+}
+
+@Article{harvey2002estimation,
+  author    = {Harvey, Euan and Fletcher, David and Shortis, Mark},
+  journal   = {Fisheries Research},
+  title     = {Estimation of reef fish length by divers and by stereo-video: a first comparison of the accuracy and precision in the field on living fish under operational conditions},
+  year      = {2002},
+  number    = {3},
+  pages     = {255--265},
+  volume    = {57},
+  groups    = {Fish Analysis},
+  publisher = {Elsevier},
+}
+
+@Article{10.1093/icesjms/fsx007,
+  author   = {Shafait, Faisal and Harvey, Euan S. and Shortis, Mark R. and Mian, Ajmal and Ravanbakhsh, Mehdi and Seager, James W. and Culverhouse, Philip F. and Cline, Danelle E. and Edgington, Duane R.},
+  journal  = {ICES Journal of Marine Science},
+  title    = {{Towards automating underwater measurement of fish length: a comparison of semi-automatic and manual stereo–video measurements}},
+  year     = {2017},
+  issn     = {1054-3139},
+  month    = {02},
+  number   = {6},
+  pages    = {1690-1701},
+  volume   = {74},
+  abstract = {Underwater stereo–video systems are widely used for counting and measuring fish in aquaculture, fisheries, and conservation management. Length measurements are generated from stereo–video recordings by a software operator using a mouse to locate the head and tail of a fish in synchronized pairs of images. This data can be used to compare spatial and temporal changes in the mean length and biomass or frequency distributions of populations of fishes. Since the early 1990s stereo–video has also been used for measuring the lengths of fish in aquaculture for quota and farm management. However, the costs of the equipment, software, the time, and salary costs involved in post processing imagery manually and the subsequent delays in the availability of length information inhibit the adoption of this technology.We present a semi-automatic method for capturing stereo–video measurements to estimate the lengths of fish. We compare the time taken to make measurements of the same fish measured manually from stereo–video imagery to that measured semi-automatically. Using imagery recorded during transfers of Southern Bluefin Tuna (SBT) from tow cages to grow out cages, we demonstrate that the semi-automatic algorithm developed can obtain fork length measurements with an error of less than 1\\% of the true length and with at least a sixfold reduction in operator time in comparison to manual measurements. Of the 22 138 SBT recorded we were able to measure 52.6\\% (11 647) manually and 11.8\\% (2614) semi-automatically. For seven of the eight cage transfers recorde,d there were no statistical differences in the mean length, weight, or length frequency between manual and semi-automatic measurements. When the data were pooled across the eight cage transfers, there was no statistical difference in mean length or weight between the stereo–video-based manual and semi-automated measurements. Hence, the presented semi-automatic system can be deployed to significantly reduce the cost involved in adoption of stereo–video technology.},
+  doi      = {10.1093/icesjms/fsx007},
+  eprint   = {https://academic.oup.com/icesjms/article-pdf/74/6/1690/31246707/fsx007.pdf},
+  groups   = {Fish Analysis, Stereo Camera},
+  url      = {https://doi.org/10.1093/icesjms/fsx007},
+}
+
+@Article{bell1985estimating,
+  author    = {Bell, JD and Craik, GJS and Pollard, DA and Russell, BC},
+  journal   = {Coral Reefs},
+  title     = {Estimating length frequency distributions of large reef fish underwater},
+  year      = {1985},
+  pages     = {41--44},
+  volume    = {4},
+  doi       = {https://doi.org/10.1007/BF00302203},
+  groups    = {Fish Analysis},
+  publisher = {Springer},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}
 
 @Comment{jabref-meta: grouping:
@@ -436,6 +496,7 @@ To the best of our knowledge, this is the first study connecting image enhanceme
 1 StaticGroup:Camera Calibration\;0\;1\;0x8a8a8aff\;\;\;;
 1 StaticGroup:Fish Analysis\;0\;1\;0x8a8a8aff\;\;\;;
 1 StaticGroup:Image Processing\;0\;1\;0x8a8a8aff\;\;\;;
+1 StaticGroup:Laser Rangefinder\;0\;1\;0x8a8a8aff\;\;\;;
 1 StaticGroup:Monocular Depth Camera\;0\;1\;0x8a8a8aff\;\;\;;
 1 StaticGroup:Optics\;0\;1\;0x8a8a8aff\;\;\;;
 1 StaticGroup:RealSense System\;0\;1\;0x8a8a8aff\;\;\;;

--- a/references/fishsense.bib
+++ b/references/fishsense.bib
@@ -489,6 +489,36 @@ To the best of our knowledge, this is the first study connecting image enhanceme
   publisher = {Springer},
 }
 
+@Article{10.1371/journal.pone.0153066,
+  author    = {Caldwell, Zachary R. AND Zgliczynski, Brian J. AND Williams, Gareth J. AND Sandin, Stuart A.},
+  journal   = {PLOS ONE},
+  title     = {Reef Fish Survey Techniques: Assessing the Potential for Standardizing Methodologies},
+  year      = {2016},
+  month     = {04},
+  number    = {4},
+  pages     = {1-14},
+  volume    = {11},
+  abstract  = {Dramatic changes in populations of fishes living on coral reefs have been documented globally and, in response, the research community has initiated efforts to assess and monitor reef fish assemblages. A variety of visual census techniques are employed, however results are often incomparable due to differential methodological performance. Although comparability of data may promote improved assessment of fish populations, and thus management of often critically important nearshore fisheries, to date no standardized and agreed-upon survey method has emerged. This study describes the use of methods across the research community and identifies potential drivers of method selection. An online survey was distributed to researchers from academic, governmental, and non-governmental organizations internationally. Although many methods were identified, 89% of survey-based projects employed one of three methods - belt transect, stationary point count, and some variation of the timed swim method. The selection of survey method was independent of the research design (i.e., assessment goal) and region of study, but was related to the researchers home institution. While some researchers expressed willingness to modify their current survey protocols to more standardized protocols (76%), their willingness decreased when methodologies were tied to long-term datasets spanning five or more years. Willingness to modify current methodologies was also less common among academic researchers than resource managers. By understanding both the current application of methods and the reported motivations for method selection, we hope to focus discussions towards increasing the comparability of quantitative reef fish survey data.},
+  doi       = {10.1371/journal.pone.0153066},
+  groups    = {Fish Analysis},
+  publisher = {Public Library of Science},
+  url       = {https://doi.org/10.1371/journal.pone.0153066},
+}
+
+@Book{alma991004472629706535,
+  author    = {Jennings, Simon and Kaiser, Michel J. and Reynolds, John D.},
+  publisher = {Blackwell Science},
+  title     = {Marine fisheries ecology},
+  year      = {2001},
+  address   = {Oxford ;},
+  isbn      = {9781444311358},
+  abstract  = {"This textbook describes fisheries exploitation, biology, conservation and management, and reflects many recent and important changes in fisheries science. These include growing concerns about the environmental impacts of fisheries, the role of ecological interactions in determining population dynamics, and the incorporation of uncertainty and precautionary principles into management advice. The book draws upon examples from tropical, temperate and polar environments, and provides readers with a broad understanding of the biological, economic and social aspects of fisheries ecology and the interplay between them. As well as covering 'classical' fisheries science, the book focuses on contemporary issues such as industrial fishing, poverty and conflict in fishing communities, marine reserves, the effects of fishing on coral reefs and by-catches of mammals, seabirds and reptiles. The book is primarily written for students of fisheries science and marine ecology, but should also appeal to practising fisheries scientists and those interested in conservation and the impacts of humans on the marine environment."--BOOK JACKET.},
+  booktitle = {Marine fisheries ecology},
+  groups    = {Fish Analysis},
+  keywords  = {Ecologie marine.},
+  language  = {eng},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}
 
 @Comment{jabref-meta: grouping:

--- a/references/fishsense.bib
+++ b/references/fishsense.bib
@@ -489,7 +489,7 @@ To the best of our knowledge, this is the first study connecting image enhanceme
   publisher = {Springer},
 }
 
-@Article{10.1371/journal.pone.0153066,
+@Article{caldwell2016,
   author    = {Caldwell, Zachary R. AND Zgliczynski, Brian J. AND Williams, Gareth J. AND Sandin, Stuart A.},
   journal   = {PLOS ONE},
   title     = {Reef Fish Survey Techniques: Assessing the Potential for Standardizing Methodologies},


### PR DESCRIPTION
Added the following sources: 
- Nguyen and Blackburn 1995
- Barreto et al. 2013
- Harvey et al. 2002
- Shafait et al. 2017
- Bell et al. 1985
- Caldwell et al. 2016
- Marine Fisheries Ecology