### PR TITLE
Add individual tracking paper to jabref

### DIFF
--- a/references/fishsense.bib
+++ b/references/fishsense.bib
@@ -140,6 +140,19 @@
   url      = {https://onlinelibrary.wiley.com/doi/abs/10.1002/ajpa.20678},
 }
 
+@Article{Brownscombe2022,
+  author  = {Brownscombe, Jacob W and Griffin, Lucas P and Brooks, Jill L and Danylchuk, Andy J and Cooke, Steven J and Midwood, Jonathan D},
+  journal = {Canadian Journal of Fisheries and Aquatic Sciences},
+  title   = {Applications of telemetry to fish habitat science and management},
+  year    = {2022},
+  number  = {8},
+  pages   = {1347--1359},
+  volume  = {79},
+  doi     = {https://doi.org/10.1139/cjfas-2021-0101},
+  groups  = {Fish Analysis},
+  url     = {https://cdnsciencepub.com/doi/10.1139/cjfas-2021-0101},
+}
+
 @Article{Buchsbaum1980,
   author   = {G. Buchsbaum},
   journal  = {Journal of the Franklin Institute},


### PR DESCRIPTION
Add the following source
- Brownscombe et al. 2022

justification for and application of scientists wanting to track individuals
> The ability to track movement of individuals over long time periods (often many years) and through different life stages also provides robust estimates of spatial scale and connectivity (e.g., for walleye (Sander vitreus) in the Great Lakes; [Hayden et al. 2014](https://cdnsciencepub.com/doi/10.1139/cjfas-2021-0101#core-ref61); [Raby et al. 2018](https://cdnsciencepub.com/doi/10.1139/cjfas-2021-0101#core-ref116); [Matley et al. 2020](https://cdnsciencepub.com/doi/10.1139/cjfas-2021-0101#core-ref97)).